### PR TITLE
Adds action to push docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  build:
+    name: Build, push, and deploy
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout master
+      uses: actions/checkout@v2
+
+    - name: Build container image
+      run: docker build --tag ghcr.io/${{ github.actor }}/nostr-gateway:$(echo $GITHUB_SHA | head -c7) .
+
+    - name: Docker login
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: docker login -u ${{ github.actor }} -p $GITHUB_TOKEN ghcr.io
+      
+    - name: Push image to GitHub
+      run: docker push ghcr.io/${{ github.actor }}/nostr-gateway:$(echo $GITHUB_SHA | head -c7)


### PR DESCRIPTION
Adds a GitHub Action to push docker images to GitHub container registry.

Packages look like so: https://github.com/hugomd/nostr-gateway/pkgs/container/nostr-gateway

`GITHUB_TOKEN` is an included secret per repository, and does not need to be set manually.