### PR TITLE
Public relay name change

### DIFF
--- a/utils/nostr.js
+++ b/utils/nostr.js
@@ -19,7 +19,7 @@ export const fallbackRelays = [
   'wss://nostr-relay.untethr.me',
   'wss://nostr-pub.wellorder.net',
   'wss://nostr.zebedee.social',
-  'wss://nostr.bitcoiner.social',
+  'wss://offchain.pub',
   'wss://nostr.fmt.wiz.biz',
   'wss://nostr-relay.wlvs.space',
   'wss://relay.snort.social',


### PR DESCRIPTION
nostr.bitcoiner.social -> offchain.pub

note1zpgy9f8tlwdwhhwtzy50vpl72qkunzhmy57p4f5xaf8h57pfvwpschwe74

> Before I deployed the new pay-to-relay server, I ran a public relay under a "nostr" subdomain. I've since renamed my public relay to wss://offchain.pub. Much cooler name. Better represents how nostr isn't something this domain handles on the side, it's the primary purpose. Raison d'etre.
> 
> Both offchain.pub and the "nostr" subdomain will work concurrently for awhile, pointing to the same public relay server. But I'll eventually deprecate the "nostr" subdomain and redirect requests to the new offchain.pub name.