### PR TITLE
Added link to event page

### DIFF
--- a/components/event.js
+++ b/components/event.js
@@ -22,14 +22,13 @@ export default function Event({id, event}) {
       </div>
     )
 
-  return (
-    <>
-      <div className="nes-container with-title">
-      <a
-      href={`/e/${id}`}
-      >
-      <p className="title id">{id}</p>
-      </a>
+return (
+  <>
+    <div className="nes-container with-title">
+      <p className="title id">
+        <a href={`/e/${id}`}>{id}</a>
+      </p>
+
 
         <div className="nes-field is-inline">
           <label htmlFor={`pubkey-${sid}`}>author</label>

--- a/components/event.js
+++ b/components/event.js
@@ -29,7 +29,6 @@ return (
         <a href={`/e/${id}`}>{id}</a>
       </p>
 
-
         <div className="nes-field is-inline">
           <label htmlFor={`pubkey-${sid}`}>author</label>
           <input

--- a/components/event.js
+++ b/components/event.js
@@ -25,7 +25,11 @@ export default function Event({id, event}) {
   return (
     <>
       <div className="nes-container with-title">
-        <p className="title id">{id}</p>
+      <a
+      href={`/e/${id}`}
+      >
+      <p className="title id">{id}</p>
+      </a>
 
         <div className="nes-field is-inline">
           <label htmlFor={`pubkey-${sid}`}>author</label>


### PR DESCRIPTION
As asked in https://github.com/fiatjaf/nostr-gateway/issues/16

![image](https://user-images.githubusercontent.com/120996278/222853530-7711b522-c16b-4e73-9054-9672dd36f4cc.png)
![image](https://user-images.githubusercontent.com/120996278/222853538-a0585a4f-7b5e-4696-88f9-c86fd1a5a102.png)

It does put the event outside of the middle of this box line for some reasons i don't understand why... 